### PR TITLE
Fix input methods list so that we have Simple Telex/Simple Telex2 work

### DIFF
--- a/src/fcitx-unikey.desc
+++ b/src/fcitx-unikey.desc
@@ -2,11 +2,14 @@
 Type=Enum
 DefaultValue=Telex
 Description=Input Method
-EnumCount=4
+EnumCount=7
 Enum0=Telex
-Enum1=Vni
-Enum2=STelex
-Enum3=STelex2
+Enum1=VNI
+Enum2=VIQR
+Enum3=Microsoft Vietnamese
+Enum4=UserIM
+Enum5=Simple Telex
+Enum6=Simple Telex2
 
 [Unikey/OutputCharset]
 Type=Enum

--- a/src/unikey-ui.cpp
+++ b/src/unikey-ui.cpp
@@ -19,8 +19,8 @@
 
 #include "unikey-im.h"
 
-const char*          Unikey_IMNames[]    = {"Telex", "Vni", "STelex", "STelex2"};
-const UkInputMethod   Unikey_IM[]         = {UkTelex, UkVni, UkSimpleTelex, UkSimpleTelex2};
+const char*          Unikey_IMNames[]    = {"Telex", "VNI", "VIQR", "Microsoft Vietnamese", "UserIM",  "Simple Telex", "Simple Telex2"};
+const UkInputMethod   Unikey_IM[]         = {UkTelex, UkVni, UkViqr, UkMsVi, UkUsrIM, UkSimpleTelex, UkSimpleTelex2};
 const unsigned int    NUM_INPUTMETHOD     = sizeof(Unikey_IM)/sizeof(Unikey_IM[0]);
 
 const char*          Unikey_OCNames[]    = {"Unicode",


### PR DESCRIPTION
The input methods list definition in fcitx-unikey is wrong, making it impossible to make simple telex to work. This fixes it so we can finally type w.
