### PR TITLE
[macro-editor] Add missing link with libintl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.2)
 
 project(fcitx-unikey)
 
@@ -26,6 +26,7 @@ find_package(Gettext REQUIRED)
 
 if (ENABLE_QT)
 find_package(Qt4 4.8)
+find_package(Intl REQUIRED)
 
 pkg_check_modules(FCITX_QT "fcitx-qt>=4.2.8")
 endif (ENABLE_QT)

--- a/macro-editor/CMakeLists.txt
+++ b/macro-editor/CMakeLists.txt
@@ -24,6 +24,7 @@ include_directories(
     ${FCITX_QT_INCLUDE_DIRS}
     ${QT_QTCORE_INCLUDE_DIR}
     ${QT_QTGUI_INCLUDE_DIR}
+    ${Intl_INCLUDE_DIRS}
     ${CMAKE_CURRENT_BINARY_DIR}
     ${PROJECT_SOURCE_DIR}/unikey
     )
@@ -51,6 +52,7 @@ target_link_libraries(fcitx-unikey-macro-editor
     ${FCITX4_FCITX_UTILS_LIBRARIES}
     ${FCITX4_FCITX_CONFIG_LIBRARIES}
     ${FCITX_QT_LIBRARIES}
+    ${Intl_LIBRARIES}
     )
 
 install(TARGETS fcitx-unikey-macro-editor DESTINATION ${FCITX4_ADDON_INSTALL_DIR}/qt)


### PR DESCRIPTION
Macro-editor uses dgettext(3), so it must be linked with libintl.